### PR TITLE
test: Upgrade react to 18 on branch smartshift-thomasuster-1690413021

### DIFF
--- a/apps/meteor/client/startup/appRoot.tsx
+++ b/apps/meteor/client/startup/appRoot.tsx
@@ -1,5 +1,5 @@
 import React, { StrictMode } from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import AppRoot from '../views/root/AppRoot';
 
@@ -16,10 +16,10 @@ const createContainer = (): Element => {
 };
 
 const container = createContainer();
+const root = createRoot(container);
 
-render(
+root.render(
 	<StrictMode>
 		<AppRoot />
-	</StrictMode>,
-	container,
+	</StrictMode>
 );

--- a/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursRouter.js
+++ b/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursRouter.js
@@ -1,6 +1,6 @@
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
 import { useRoute, useRouteParameter } from '@rocket.chat/ui-contexts';
-import React, { useEffect } from 'react';
+import React, { useInsertionEffect } from 'react';
 
 import { businessHourManager } from '../../../../app/livechat/client/views/app/business-hours/BusinessHours';
 import { useReactiveValue } from '../../../hooks/useReactiveValue';
@@ -19,7 +19,7 @@ const BusinessHoursRouter = () => {
 
 	const router = useRoute('omnichannel-businessHours');
 
-	useEffect(() => {
+	useInsertionEffect(() => {
 		if (isSingleBH) {
 			router.push({
 				context: 'edit',

--- a/packages/livechat/src/components/Screen/index.js
+++ b/packages/livechat/src/components/Screen/index.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'preact/hooks';
+import { useInsertionEffect } from 'preact/hooks';
 
 import ChatIcon from '../../icons/chat.svg';
 import CloseIcon from '../../icons/close.svg';
@@ -38,7 +38,7 @@ const ChatButton = ({ text, minimized, badge, onClick, triggered = false, agent 
 );
 
 const CssVar = ({ theme }) => {
-	useEffect(() => {
+	useInsertionEffect(() => {
 		if (window.CSS && CSS.supports('color', 'var(--color)')) {
 			return;
 		}

--- a/packages/livechat/svg-component-loader.js
+++ b/packages/livechat/svg-component-loader.js
@@ -8,7 +8,7 @@ var content = module.exports.content;
 module.exports = function (props) {
 	var ref = hooks.useRef();
 
-	hooks.useEffect(function () {
+	hooks.useInsertionEffect(function () {
 		var div = document.createElement('div');
 		div.innerHTML = '<svg>' + content + '</svg>';
 

--- a/packages/uikit-playground/src/main.tsx
+++ b/packages/uikit-playground/src/main.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import '@rocket.chat/icons/dist/rocketchat.css';
 
 import './index.css';
 import App from './App';
 import { Provider } from './Context';
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <React.StrictMode>
     <Provider>
       <App />
     </Provider>
-  </React.StrictMode>,
-  document.getElementById('root'),
+  </React.StrictMode>
 );


### PR DESCRIPTION
# test
## Tasks
### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - apps/meteor/client/views/omnichannel/businessHours/BusinessHoursRouter.js
    - packages/livechat/src/components/Screen/index.js
    - packages/livechat/svg-component-loader.js
### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- If using render imported from react-dom, replace it with createRoot
    - apps/meteor/client/startup/appRoot.tsx
    - packages/uikit-playground/src/main.tsx

## Errors

### Update Client Rendering APIs
React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.

#### Instructions
- If using render imported from react-dom, replace it with createRoot
    - migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/providers/CallProvider/CallProvider.tsx: migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/providers/CallProvider/CallProvider.tsx for task: Update Client Rendering APIs, step: If using render imported from react-dom, replace it with createRoot exceeds 2000 tokens and not currently supported. 

### Adopt new hooks
Adopt the useSyncExternalStore and useInsertionEffect hooks introduced in React 18

#### Instructions
- Replace any CSS-in-JS style injections in render with useInsertionEffect
    - migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/views/admin/users/UserForm.js: migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/views/admin/users/UserForm.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 

    - migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/views/admin/import/NewImportPage.js: migrations/test/switchkeep/Rocket.Chat/apps/meteor/client/views/admin/import/NewImportPage.js for task: Adopt new hooks, step: Replace any CSS-in-JS style injections in render with useInsertionEffect exceeds 2000 tokens and not currently supported. 
